### PR TITLE
uses threading to run api and anvil listener

### DIFF
--- a/scripts/demo_setup_script.py
+++ b/scripts/demo_setup_script.py
@@ -540,17 +540,6 @@ def main():
     
     flask_thread.join()
     block_listener_thread.join()
-    # # Subscribe to new block headers
-    # chain_a_block_filter = chain_a_web3.eth.filter('latest')
-    # # start API
-    # CORS(app)
-    # app.run(host='0.0.0.0', port=5001)
-    # print("Listening for new blocks...")
-    # while True:
-    #     for block_hash in chain_a_block_filter.get_new_entries():
-    #         block = chain_a_web3.eth.get_block(block_hash)
-    #         # TODO: SPVM blocks happen on even L1 block numbers, validity conditions are posted on odd L1 block numbers.
-    #         handle_new_block(block, chain_a_election_contract, chain_a_web3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes a bug in the setup script where the Flask app setup was blocking part of the anvil script